### PR TITLE
FO-2548: Fikse app layout i testmiljø

### DIFF
--- a/src/view/App.less
+++ b/src/view/App.less
@@ -1,23 +1,30 @@
 @import '~nav-frontend-core/less/core';
 
-body {
-    margin: 0;
-}
-
 html,
 body,
 #root,
 .app {
     height: 100%;
+}
+body {
     display: flex;
     flex-direction: column;
-    color: @navMorkGra;
+}
+
+#pagewrapper {
+    margin-bottom: 0 !important; //overstyrer decorator
+    padding-bottom: 0 !important; //overstyrer decorator
+    display: flex;
+    flex-direction: column;
+}
+
+#maincontent {
+    height: 100%;
 }
 
 .app__body {
     display: flex;
     background-color: @navLysGra;
     padding-left: 1rem;
-    height: 100%;
-    justify-content: center;
+    height: calc(100% - 100px); //Trekke fra banner str
 }

--- a/src/view/banner/AppBanner.less
+++ b/src/view/banner/AppBanner.less
@@ -9,6 +9,8 @@
     align-items: center;
     flex-basis: 5rem;
     flex-direction: column;
+    height: 100px;
+
     &__lenke {
         margin-right: 1rem;
         align-self: flex-start;


### PR DESCRIPTION
Fix for å få riktig layout på appen.
Dekoratør header og appinnholdet skal være i skjermens høyde, footer skal være nedenfor så man alltid på scrolle for å komme dit.

Måtte overstyre dekoratør styling på pagewrapper padding/margin fordi eller så får jeg ikke footeren under skjermen

Satt høyde på banner og app__body(hører til samme flex container) for at scroll skal fungere

Banner skal ikke vises på mobil(kommer i en annen pr)
![Skjermbilde 2019-11-13 kl  14 49 31](https://user-images.githubusercontent.com/1025788/68769852-52be9600-0625-11ea-9da9-253749bf7be8.png)
![Skjermbilde 2019-11-13 kl  14 49 49](https://user-images.githubusercontent.com/1025788/68769863-56521d00-0625-11ea-88fb-3dd38ed37041.png)
![Skjermbilde 2019-11-13 kl  14 50 47](https://user-images.githubusercontent.com/1025788/68769868-594d0d80-0625-11ea-9a0e-d1d90bcc8c69.png)



