### PR TITLE
[KAIZEN-0] fjerner /dialog fra baspath

### DIFF
--- a/src/view/App.tsx
+++ b/src/view/App.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 function App(props: Props) {
-    const baspath = props.fnr ? `/veilarbpersonflatefs/${props.fnr}/dialog/` : process.env.PUBLIC_URL;
+    const baspath = props.fnr ? `/veilarbpersonflatefs/${props.fnr}` : process.env.PUBLIC_URL;
 
     return (
         <Router basename={baspath}>


### PR DESCRIPTION
da veilarbpersonflatefs ikke setter /dialog
når denne mountes blir ikke routs aktive
da den er utenfor baspath