### PR TITLE
Legge inn riktig tekst på feilmeldinger og bruke Alertstripe-komponent

### DIFF
--- a/src/api/useHentVeilederData.ts
+++ b/src/api/useHentVeilederData.ts
@@ -14,7 +14,7 @@ const useFetchVeilederNavn = (erVeileder: boolean) => {
     useEffect(() => {
         if (erVeileder) {
             fetchData<VeilederInfo>('/veilarbveileder/api/veileder/me')
-                .then(veilerder => setVeilederNavn(`${veilerder.fornavn} ${veilerder.etternavn}`))
+                .then((veilerder) => setVeilederNavn(`${veilerder.fornavn} ${veilerder.etternavn}`))
                 .catch();
         }
     }, [erVeileder]);

--- a/src/felleskomponenter/AlertStripeFeilVisible.tsx
+++ b/src/felleskomponenter/AlertStripeFeilVisible.tsx
@@ -1,0 +1,4 @@
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { visibleIfHoc } from './VisibleIfHoc';
+
+export default visibleIfHoc(AlertStripeFeil);

--- a/src/view/App.module.less
+++ b/src/view/App.module.less
@@ -100,7 +100,3 @@
     width: 100%;
     max-width: 1920px;
 }
-
-.feil {
-    margin: 1rem;
-}

--- a/src/view/App.module.less
+++ b/src/view/App.module.less
@@ -100,3 +100,7 @@
     width: 100%;
     max-width: 1920px;
 }
+
+.feil {
+    margin: 1rem;
+}

--- a/src/view/Provider.module.less
+++ b/src/view/Provider.module.less
@@ -1,0 +1,3 @@
+.feil {
+    margin: 1rem;
+}

--- a/src/view/Provider.tsx
+++ b/src/view/Provider.tsx
@@ -9,7 +9,7 @@ import { AktivitetProvider } from './AktivitetProvider';
 import { DialogContext, hasDialogError, isDialogOk, isDialogPending, useDialogDataProvider } from './DialogProvider';
 import useFetchVeilederNavn from '../api/useHentVeilederData';
 import { KladdContext, useKladdDataProvider } from './KladdProvider';
-import styles from './App.module.less';
+import styles from './Provider.module.less';
 
 interface VeilederData {
     veilederNavn?: string;

--- a/src/view/Provider.tsx
+++ b/src/view/Provider.tsx
@@ -1,13 +1,15 @@
 import React, { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
-import { Bruker, OppfolgingData } from '../utils/Typer';
-import NavFrontendSpinner from 'nav-frontend-spinner';
 import useFetch, { FetchResult, hasData, hasError, isPending, Status } from '@nutgaard/use-fetch';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import NavFrontendSpinner from 'nav-frontend-spinner';
+import { Bruker, OppfolgingData } from '../utils/Typer';
 import { fnrQuery, getApiBasePath, REQUEST_CONFIG } from '../utils/Fetch';
 import { initalState, ViewState } from './ViewState';
 import { AktivitetProvider } from './AktivitetProvider';
 import { DialogContext, hasDialogError, isDialogOk, isDialogPending, useDialogDataProvider } from './DialogProvider';
 import useFetchVeilederNavn from '../api/useHentVeilederData';
 import { KladdContext, useKladdDataProvider } from './KladdProvider';
+import styles from './App.module.less';
 
 interface VeilederData {
     veilederNavn?: string;
@@ -91,7 +93,11 @@ export function Provider(props: Props) {
     if (isDialogPending(status) || isPending(bruker, false) || isPending(oppfolgingData, false)) {
         return <NavFrontendSpinner />;
     } else if (hasError(bruker) || hasError(oppfolgingData) || hasDialogError(status)) {
-        return <p>Kunne ikke laste data fra baksystemer. Prøv igjen senere</p>;
+        return (
+            <AlertStripeFeil className={styles.feil}>
+                Noe gikk dessverre galt med systemet. Prøv igjen senere.
+            </AlertStripeFeil>
+        );
     }
 
     return (

--- a/src/view/aktivitet/Aktivitetskort.tsx
+++ b/src/view/aktivitet/Aktivitetskort.tsx
@@ -16,7 +16,7 @@ export function Aktivitetskort() {
     const { dialogId } = useParams();
     const aktivitetData = useAktivitetContext();
 
-    const dialog = dialoger.find(dialog => dialog.id === dialogId);
+    const dialog = dialoger.find((dialog) => dialog.id === dialogId);
     const aktivitetId = useAktivitetId() ?? dialog?.aktivitetId;
     const aktivitet = findAktivitet(aktivitetData, aktivitetId);
 

--- a/src/view/aktivitet/AktivitetskortPreview.tsx
+++ b/src/view/aktivitet/AktivitetskortPreview.tsx
@@ -23,6 +23,7 @@ export function AktivitetskortPreview(props: Props) {
     const apiBasePath = useApiBasePath();
 
     const aktivitet = findAktivitet(aktvitetData, aktivitetId);
+
     if (!aktivitet) {
         return null;
     }

--- a/src/view/dialog/DialogHeader.module.less
+++ b/src/view/dialog/DialogHeader.module.less
@@ -63,3 +63,9 @@
 
     .max-responsive({margin-left: -2.58rem; padding-left: 2.58rem;});
 }
+
+.feil {
+    padding: 1rem;
+    background-color: @lysgraBakrund;
+    z-index: 1000;
+}

--- a/src/view/dialog/DialogHeader.tsx
+++ b/src/view/dialog/DialogHeader.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { VenstreChevron } from 'nav-frontend-chevron';
-import { DialogData, StringOrNull } from '../../utils/Typer';
-import { AktivitetskortPreview } from '../aktivitet/AktivitetskortPreview';
-import { Systemtittel, Undertittel } from 'nav-frontend-typografi';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
-import styles from './DialogHeader.module.less';
+import { VenstreChevron } from 'nav-frontend-chevron';
+import { Systemtittel, Undertittel } from 'nav-frontend-typografi';
+import { hasError } from '@nutgaard/use-fetch';
+import { DialogData, StringOrNull } from '../../utils/Typer';
+import { AktivitetskortPreview } from '../aktivitet/AktivitetskortPreview';
 import { ReactComponent as Lukk } from '../../fellesikoner/lukk.svg';
+import { AktivitetContextType, useAktivitetContext } from '../AktivitetProvider';
+import DialogHeaderFeil from './DialogHeaderFeil';
+import styles from './DialogHeader.module.less';
 
 export const dialogHeaderID1 = 'dialog_header_1';
 export const dialogHeaderID2 = 'dialog_header_2';
@@ -33,21 +36,38 @@ function DialogOverskrift(props: DialogOverskriftProps) {
     );
 }
 
+function harAktivitetDataFeil(aktivitetData: AktivitetContextType, aktivitetId?: string | null) {
+    if (!aktivitetId) return false;
+
+    if (aktivitetId.startsWith('ARENA')) {
+        return hasError(aktivitetData.arenaAktiviter);
+    } else {
+        return hasError(aktivitetData.aktiviteter);
+    }
+}
+
 export function DialogHeader(props: DialogHeaderProps) {
     const { dialog, aktivitetId, visSkygge } = props;
     const aktivitet = aktivitetId || dialog?.aktivitetId;
 
+    const aktvitetData = useAktivitetContext();
+
+    const erFeil = harAktivitetDataFeil(aktvitetData, aktivitet);
+
     return (
-        <Header visSkygge={visSkygge}>
-            <div id={dialogHeaderID1} className="hide">
-                Dialog om:
-            </div>
-            {aktivitet ? (
-                <AktivitetskortPreview aktivitetId={aktivitet} />
-            ) : (
-                <DialogOverskrift tekst={dialog?.overskrift} />
-            )}
-        </Header>
+        <>
+            <DialogHeaderFeil visible={erFeil} />
+            <Header visSkygge={visSkygge}>
+                <div id={dialogHeaderID1} className="hide">
+                    Dialog om:
+                </div>
+                {aktivitet && !erFeil ? (
+                    <AktivitetskortPreview aktivitetId={aktivitet} />
+                ) : (
+                    <DialogOverskrift tekst={dialog?.overskrift} />
+                )}
+            </Header>
+        </>
     );
 }
 

--- a/src/view/dialog/DialogHeaderFeil.tsx
+++ b/src/view/dialog/DialogHeaderFeil.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import styles from './DialogHeader.module.less';
+
+interface Props {
+    visible: boolean;
+}
+
+function DialogHeaderFeil(props: Props) {
+    const { visible } = props;
+
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <div className={styles.feil}>
+            <AlertStripeFeil>
+                Noe gikk galt, og du får dessverre ikke sett informasjon fra aktivitetsplanen. Prøv igjen senere.
+            </AlertStripeFeil>
+        </div>
+    );
+}
+
+export default DialogHeaderFeil;

--- a/src/view/dialog/DialogInputBox.module.less
+++ b/src/view/dialog/DialogInputBox.module.less
@@ -1,0 +1,3 @@
+.feil {
+    margin: 1rem;
+}

--- a/src/view/dialog/DialogInputBox.tsx
+++ b/src/view/dialog/DialogInputBox.tsx
@@ -1,20 +1,18 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { DialogData } from '../../utils/Typer';
-import { visibleIfHoc } from '../../felleskomponenter/VisibleIfHoc';
 import { dataOrUndefined, useOppfolgingContext, useUserInfoContext, useViewContext } from '../Provider';
-import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import useFormstate, { Formstate } from '@nutgaard/use-formstate';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { HandlingsType, sendtNyHenvendelse } from '../ViewState';
 import { dispatchUpdate, UpdateTypes } from '../../utils/UpdateEvent';
-import { isDialogPendingOrReloading, useDialogContext } from '../DialogProvider';
+import { useDialogContext } from '../DialogProvider';
 import useHenvendelseStartTekst from './UseHenvendelseStartTekst';
 import loggEvent from '../../felleskomponenter/logging';
 import { useKladdContext } from '../KladdProvider';
 import EkspanderbartTekstArea from '../../felleskomponenter/textArea/TextArea';
 import { smoothScrollToLastHenvendelse } from '../henvendelse/useScrollToLastHenvendelse';
-
-const AlertStripeFeilVisible = visibleIfHoc(AlertStripeFeil);
+import AlertStripeFeilVisible from '../../felleskomponenter/AlertStripeFeilVisible';
+import styles from './DialogInputBox.module.less';
 
 const maxMeldingsLengde = 5000;
 
@@ -77,8 +75,7 @@ export function DialogInputBox(props: Props) {
     const bruker = useUserInfoContext();
     const oppfolgingContext = useOppfolgingContext();
     const oppfolging = dataOrUndefined(oppfolgingContext);
-    const { hentDialoger, nyHenvendelse, setFerdigBehandlet, status } = useDialogContext();
-    const dialogLaster = isDialogPendingOrReloading(status);
+    const { hentDialoger, nyHenvendelse, setFerdigBehandlet } = useDialogContext();
     const [noeFeilet, setNoeFeilet] = useState(false);
     const startTekst = useHenvendelseStartTekst();
 
@@ -126,6 +123,7 @@ export function DialogInputBox(props: Props) {
     }
 
     const onSubmit = (data: { melding: string }) => {
+        setNoeFeilet(false);
         const { melding } = data;
 
         timer.current && clearInterval(timer.current);
@@ -154,8 +152,6 @@ export function DialogInputBox(props: Props) {
             .catch(() => setNoeFeilet(true));
     };
 
-    const laster = state.submitting || dialogLaster;
-
     const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         timer.current && clearInterval(timer.current);
@@ -170,13 +166,13 @@ export function DialogInputBox(props: Props) {
         <section aria-label="Ny melding">
             <form onSubmit={state.onSubmit(onSubmit)} noValidate autoComplete="off">
                 <HenvendelseInput
-                    laster={laster}
+                    laster={state.submitting}
                     state={state}
                     onChange={onChange}
                     kanSendeHenvendelse={kanSendeHenveldelse}
                 />
-                <AlertStripeFeilVisible visible={noeFeilet}>
-                    Det skjedde en alvorlig feil. Prøv igjen senere
+                <AlertStripeFeilVisible visible={noeFeilet} className={styles.feil}>
+                    Noe gikk dessverre galt med systemet. Prøv igjen senere.
                 </AlertStripeFeilVisible>
             </form>
         </section>

--- a/src/view/dialog/NyDialogForm.module.less
+++ b/src/view/dialog/NyDialogForm.module.less
@@ -51,3 +51,7 @@
 
     .min-responsive({.infotekst {max-width: 30rem;}});
 }
+
+.feil {
+    margin-top: 1rem;
+}

--- a/src/view/dialog/NyDialogForm.tsx
+++ b/src/view/dialog/NyDialogForm.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 import useFormstate from '@nutgaard/use-formstate';
-import { useUserInfoContext } from '../Provider';
 import { useHistory } from 'react-router';
-import { AlertStripeFeil } from 'nav-frontend-alertstriper';
-import { visibleIfHoc } from '../../felleskomponenter/VisibleIfHoc';
 import { Hovedknapp } from 'nav-frontend-knapper';
+import { SkjemaGruppe } from 'nav-frontend-skjema';
+import { useUserInfoContext } from '../Provider';
 import Input from '../../felleskomponenter/input/input';
-import style from './NyDialogForm.module.less';
 import { StringOrNull } from '../../utils/Typer';
 import { dispatchUpdate, UpdateTypes } from '../../utils/UpdateEvent';
 import { useDialogContext } from '../DialogProvider';
@@ -15,9 +13,8 @@ import useHenvendelseStartTekst from './UseHenvendelseStartTekst';
 import loggEvent from '../../felleskomponenter/logging';
 import { findKladd, useKladdContext } from '../KladdProvider';
 import EkspanderbartTekstArea from '../../felleskomponenter/textArea/TextArea';
-import { SkjemaGruppe } from 'nav-frontend-skjema';
-
-const AlertStripeFeilVisible = visibleIfHoc(AlertStripeFeil);
+import AlertStripeFeilVisible from '../../felleskomponenter/AlertStripeFeilVisible';
+import style from './NyDialogForm.module.less';
 
 const maxMeldingsLengde = 5000;
 const veilederInfoMelding = 'Skriv en melding til brukeren';
@@ -161,8 +158,8 @@ function NyDialogForm(props: Props) {
                     Send
                 </Hovedknapp>
 
-                <AlertStripeFeilVisible visible={noeFeilet}>
-                    Det skjedde en alvorlig feil. Prøv igjen senere
+                <AlertStripeFeilVisible visible={noeFeilet} className={style.feil}>
+                    Noe gikk dessverre galt med systemet. Prøv igjen senere.
                 </AlertStripeFeilVisible>
             </form>
         </div>


### PR DESCRIPTION
1. I dialogen, hvis et datapunkt ikke kan hentes
vise øverst i appen en alertstripe (type=feil) med teksten "Noe gikk dessverre galt med systemet. Prøv igjen senere."
 
2. I dialogen, hvis aktiviteter ikke blir hentet: 
vise øverst i appen en alertstripe (type=feil) med teksten "Noe gikk galt, og du får dessverre ikke sett informasjon fra aktivitetsplanen. Prøv igjen senere."

3. I dialogen, ny dialog, hvis prøver å sende melding
ved sendingsfeltet vise alertstripe type=feil med teksten "Noe gikk dessverre galt med systemet. Prøv igjen senere."

4. I dialogen, vanlige inputfeltet, hvis prøver å sende en melding på en eksisterende dialog
ved sendingsfeltet vise alertstripe type=feil med teksten "Noe gikk dessverre galt med systemet. Prøv igjen senere." "
så skal send-knappen ikke være disabled (en skal få prøve å sende på nytt)  