### PR TITLE
Fjerne ulestmarkering og etiketter på historiske dialoger

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     },
     "lint-staged": {
         "*.{js,ts,tsx,json,less,css,md}": [
-            "prettier --write",
-            "git add"
+            "prettier --write"
         ]
     },
     "eslintConfig": {

--- a/src/view/dialogliste/DialogPreview.tsx
+++ b/src/view/dialogliste/DialogPreview.tsx
@@ -48,16 +48,19 @@ interface Props {
 
 function DialogPreview(props: Props) {
     const { dialog, valgtDialogId } = props;
-    const { id, sisteDato, aktivitetId, lest, overskrift } = dialog;
+    const { id, sisteDato, aktivitetId, lest, overskrift, historisk } = dialog;
     const aktivitetData = useAktivitetContext();
 
     const datoString = !!sisteDato ? formaterDate(sisteDato) : '';
     const aktivitet = findAktivitet(aktivitetData, aktivitetId);
+
+    const erLest = lest || historisk;
+
     const lenkepanelCls = classNames(styles.preview, {
-        [styles.innholdUlest]: !lest,
+        [styles.innholdUlest]: !erLest,
         [styles.innholdValgt]: id === valgtDialogId
     });
-    const markoer = lest ? styles.markoerLest : styles.markoerUlest;
+    const markoer = erLest ? styles.markoerLest : styles.markoerUlest;
 
     return (
         <LenkepanelBase className={lenkepanelCls} href={`/${id}`} linkCreator={WrapInReactLink}>

--- a/src/view/dialogliste/EtikettListe.tsx
+++ b/src/view/dialogliste/EtikettListe.tsx
@@ -23,6 +23,11 @@ function erViktig(dialog: DialogData, oppfolging?: OppfolgingData): boolean {
 export function EtikettListe(props: Props) {
     const userInfo = useContext(UserInfoContext);
     const oppfolging = useOppfolgingContext();
+
+    if (props.dialog.historisk) {
+        return null;
+    }
+
     const erVeileder = !!userInfo && userInfo.erVeileder;
 
     const dialogErViktig = erViktig(props.dialog, dataOrUndefined(oppfolging));

--- a/src/view/dialogliste/ikon/Ikon.module.less
+++ b/src/view/dialogliste/ikon/Ikon.module.less
@@ -7,7 +7,7 @@
     position: relative;
 }
 
-.lestIkon:after {
+.ulestIkon:after {
     content: '';
     height: 8px;
     width: 8px;

--- a/src/view/dialogliste/ikon/Ikon.tsx
+++ b/src/view/dialogliste/ikon/Ikon.tsx
@@ -11,7 +11,7 @@ interface IkonProps {
 
 function DialogPreviewIkon(props: IkonProps) {
     const erAktivitet: boolean = props.dialog.aktivitetId !== null;
-    const ikonCls = classNames(styles.ikon, { [styles.lestIkon]: !props.dialog.lest });
+    const ikonCls = classNames(styles.ikon, { [styles.ulestIkon]: !props.dialog.lest && !props.dialog.historisk });
     if (erAktivitet) {
         return (
             <div aria-hidden="true" className={ikonCls}>


### PR DESCRIPTION
Fjern ulest visning på historiserte dialoger. Dette kan skje, men er veldig rart og vi burde bare skjule for bruker og veileder at dette er tilfellet. Men den skal ikke da komme som "lest" av bruker.