### PR TITLE
Gjøre infomelding synlig for veileder på stor skjerm

### DIFF
--- a/src/view/dialog/DialogInfoMelding.tsx
+++ b/src/view/dialog/DialogInfoMelding.tsx
@@ -3,18 +3,18 @@ import React from 'react';
 import { useDialogContext } from '../DialogProvider';
 import DialogIkkeValgt from '../info/DialogIkkeValgt';
 import InfoVedIngenDialoger from '../info/InfoVedIngenDialoger';
-import { useUserInfoContext } from '../Provider';
 import styles from './DialogInfoMelding.module.less';
 
-export default function DialogInfoMelding() {
+const DialogInfoMelding = () => {
     const { dialoger } = useDialogContext();
-    const bruker = useUserInfoContext();
     const harDialoger = dialoger.length > 0;
 
     return (
         <>
-            <InfoVedIngenDialoger className={styles.info} visible={!bruker?.erVeileder && !harDialoger} />
+            <InfoVedIngenDialoger className={styles.info} visible={!harDialoger} />
             <DialogIkkeValgt className={styles.info} visible={harDialoger} />
         </>
     );
-}
+};
+
+export default DialogInfoMelding;


### PR DESCRIPTION
Oppgaven løser punktet beskrevet under fra dette kortet: https://trello.com/c/nGohCj8V/80-diverse-sm%C3%A5feil-i-dialogen-bughunt
> Når du ikke har noen dialoger og har liten skjerm så får du infomelding men ikke når du har stor skjerm