### PR TITLE
Fikse bug som gjør at nyDialog ikke blir rendra når arenaaktiviteter ikke er tilgjengelig

### DIFF
--- a/src/utils/Typer.ts
+++ b/src/utils/Typer.ts
@@ -1,6 +1,8 @@
 export type ValueOrNull<T> = T | null;
 export type StringOrNull = ValueOrNull<string>;
 export type NumberOrNull = ValueOrNull<number>;
+export type ValueOrUndefined<T> = T | undefined;
+export type StringOrUndefined = ValueOrUndefined<string>;
 
 export interface NyDialogMeldingData {
     tekst: string;

--- a/src/view/AktivitetProvider.tsx
+++ b/src/view/AktivitetProvider.tsx
@@ -31,13 +31,6 @@ const inital: AktivitetContextType = {
 export const AktivitetContext = React.createContext(inital);
 export const useAktivitetContext = () => useContext(AktivitetContext);
 
-export function isLoadingData(aktivitetData: AktivitetContextType): boolean {
-    const aktiviteter = hasData(aktivitetData.aktiviteter);
-    const arena = hasData(aktivitetData.arenaAktiviter);
-
-    return !aktiviteter || !arena;
-}
-
 export function harAktivitetDataFeil(aktivitetData: AktivitetContextType, arenaAktivitet: boolean): boolean {
     if (arenaAktivitet) {
         return hasError(aktivitetData.arenaAktiviter);

--- a/src/view/dialog/NyDialog.tsx
+++ b/src/view/dialog/NyDialog.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 
+import { StringOrUndefined } from '../../utils/Typer';
 import useKansendeMelding from '../../utils/UseKanSendeMelding';
 import { getDialogTittel } from '../aktivitet/TextUtils';
-import { findAktivitet, isLoadingData, useAktivitetContext } from '../AktivitetProvider';
+import { AktivitetContextType, MaybeAktivitet, findAktivitet, useAktivitetContext } from '../AktivitetProvider';
 import { useViewContext } from '../Provider';
 import { useAktivitetId } from '../utils/useAktivitetId';
 import { useSkjulHodefotForMobilVisning } from '../utils/useSkjulHodefotForMobilVisning';
@@ -14,12 +15,11 @@ export default function NyDialog() {
     const kansendeMelding = useKansendeMelding();
     useSkjulHodefotForMobilVisning();
 
-    const aktivitetId = useAktivitetId();
-    const aktivitetData = useAktivitetContext();
+    const aktivitetId: StringOrUndefined = useAktivitetId();
+    const aktivitetData: AktivitetContextType = useAktivitetContext();
+    const aktivitet: MaybeAktivitet = findAktivitet(aktivitetData, aktivitetId);
 
-    const aktivitet = findAktivitet(aktivitetData, aktivitetId);
     const defaultTema = getDialogTittel(aktivitet);
-    const loadingData = isLoadingData(aktivitetData);
 
     const { viewState, setViewState } = useViewContext();
 
@@ -27,7 +27,7 @@ export default function NyDialog() {
         setViewState(endreDialogSomVises());
     }, [setViewState]);
 
-    if (!kansendeMelding || (aktivitetId && loadingData)) {
+    if (!kansendeMelding || (aktivitetId && !aktivitet)) {
         return <div className={styles.dialog} />;
     }
 


### PR DESCRIPTION
arenaaktiviteter trenger ikke å være ferdig fetcha eller tilgjengelig for å opprette dialog på en annen type aktivitet