### PR TITLE
Fjerne stylingfiks på NyDialog-knapp for å ta bort dobbel tabbing

### DIFF
--- a/src/view/dialogliste/NyDialogLink.module.less
+++ b/src/view/dialogliste/NyDialogLink.module.less
@@ -7,5 +7,33 @@
 }
 
 .dialogKnapp {
-    text-decoration: none;
+    //Hovedknapp total mixin start = .knapp .knapp--hoved
+    .knappbase-mixin(@font-family);
+    .knappramme-mixin(@navBla, @navDypBla, @white);
+    .knappdisabled-mixin();
+    .knappspinner-mixin();
+    .knappmedikon-mixin();
+    .knappfylt-mixin(@navBla, @white, @navDypBla, lighten(@navBla, 5%));
+    //Hovedknapp total mixin slutt
+
+    display: flex;
+    padding: 0.3rem 1rem 0.3rem 1rem;
+    .plusslogo {
+        fill: @white;
+        margin-right: 0.5rem;
+        align-self: center;
+    }
+
+    &:focus {
+        .plusslogo {
+            fill: @navBla;
+        }
+    }
+
+    &:active,
+    &:hover {
+        .plusslogo {
+            fill: @white;
+        }
+    }
 }

--- a/src/view/dialogliste/NyDialogLink.tsx
+++ b/src/view/dialogliste/NyDialogLink.tsx
@@ -1,20 +1,17 @@
-import { Hovedknapp } from 'nav-frontend-knapper';
 import React from 'react';
-import { useHistory } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import { visibleIfHoc } from '../../felleskomponenter/VisibleIfHoc';
 import styles from './NyDialogLink.module.less';
 import { ReactComponent as PlussIkon } from './pluss.svg';
 
 const NyDialogLink = () => {
-    const history = useHistory();
-
     return (
         <div className={styles.header}>
-            <Hovedknapp kompakt onClick={() => history.push('/ny')}>
+            <Link className={styles.dialogKnapp} to={'/ny'}>
                 <PlussIkon className={styles.plusslogo} />
-                <span>Ny dialog</span>
-            </Hovedknapp>
+                Ny dialog
+            </Link>
         </div>
     );
 };

--- a/src/view/dialogliste/NyDialogLink.tsx
+++ b/src/view/dialogliste/NyDialogLink.tsx
@@ -1,20 +1,21 @@
 import { Hovedknapp } from 'nav-frontend-knapper';
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router';
 
 import { visibleIfHoc } from '../../felleskomponenter/VisibleIfHoc';
 import styles from './NyDialogLink.module.less';
 import { ReactComponent as PlussIkon } from './pluss.svg';
 
-const NyDialogLink = () => (
-    <div className={styles.header}>
-        <Link to={'/ny'} className={styles.dialogKnapp}>
-            <Hovedknapp kompakt>
+const NyDialogLink = () => {
+    const history = useHistory();
+
+    return (
+        <div className={styles.header}>
+            <Hovedknapp kompakt onClick={() => history.push('/ny')}>
                 <PlussIkon className={styles.plusslogo} />
                 <span>Ny dialog</span>
             </Hovedknapp>
-        </Link>
-    </div>
-);
-
+        </div>
+    );
+};
 export default visibleIfHoc(NyDialogLink);


### PR DESCRIPTION
Ved å wrappe hovedknappen i en `Link`, så måtte man tabbe på knappen to ganger for å komme videre til neste element. Har derfor tatt tilbake til sånn det var før. Lager en ny oppgave på å fikse knappen