### PR TITLE
Fix timeoutmodal

### DIFF
--- a/src/felleskomponenter/timeoutmodal/TimeoutModal.tsx
+++ b/src/felleskomponenter/timeoutmodal/TimeoutModal.tsx
@@ -4,9 +4,10 @@ import { Hovedknapp } from 'nav-frontend-knapper';
 import NavFrontendModal from 'nav-frontend-modal';
 import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import Veilederpanel from 'nav-frontend-veilederpanel';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { getApiBasePath } from '../../utils/Fetch';
+import { UserInfoContext } from '../../view/Provider';
 import { hiddenIfHoc } from '../HiddenIfHoc';
 import { ReactComponent as ObsSVG } from './obs.svg';
 
@@ -31,6 +32,12 @@ interface Props {
 function TimeoutModal(props: Props) {
     const { visDemo, fnr } = props;
     const [skalVises, setSkalVises] = useState(false);
+
+    const userInfo = useContext(UserInfoContext);
+
+    const baseUrl = userInfo?.erVeileder
+        ? window.location.origin + '/veilarbpersonflatefs'
+        : window.location.origin + '/arbeid/dialog';
 
     useEffect(() => {
         fetch(getApiBasePath(fnr) + '/api/auth', {
@@ -82,7 +89,11 @@ function TimeoutModal(props: Props) {
                         Du kan fortsette der du slapp etter innlogging.
                     </Normaltekst>
 
-                    <Hovedknapp className="timeoutbox-modal__startpaanytt" onClick={() => window.location.reload()}>
+                    <Hovedknapp
+                        className="timeoutbox-modal__startpaanytt"
+                        onClick={() => window.location.assign(baseUrl)}
+                    >
+                        {/* Loginservice støtter kun returnurl til baseUrl */}
                         Start på nytt nå
                     </Hovedknapp>
                 </div>

--- a/src/felleskomponenter/timeoutmodal/TimeoutModal.tsx
+++ b/src/felleskomponenter/timeoutmodal/TimeoutModal.tsx
@@ -23,10 +23,6 @@ function getHeaders() {
     };
 }
 
-function utloptTidspunktMinusSeksMinutter(remainingSeconds: number): number {
-    return (remainingSeconds - 360) * 1000;
-}
-
 interface Props {
     fnr?: string;
     visDemo?: boolean;
@@ -48,7 +44,7 @@ function TimeoutModal(props: Props) {
                 const { remainingSeconds } = authExp;
 
                 if (remainingSeconds) {
-                    const expirationInMillis = utloptTidspunktMinusSeksMinutter(remainingSeconds);
+                    const expirationInMillis = remainingSeconds * 1000;
                     const expiresAt = new Date().getTime() + expirationInMillis;
 
                     setTimeout(() => {


### PR DESCRIPTION
- Dersom brukeren står inne i en spesifikk dialog, vil urlen inneholde dialogId. Loginservice støtter ikke "returnUrl" med url path-parametre.
En foreslått fix er å gjøre reload av baseUrl i stedet, slik at bruker kommer inn på toppnivå i dialogen.
 - Når brukeren får TimeoutModal popup, går det enda 6 minutter før ny innlogging faktisk blir trigget, så reload kommer opp med samme modal aktiv