### PR TITLE
Legg til ukentlig Dependabot + Copilot-oppdateringsoppsett

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: monday
+      time: "07:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: monday
+      time: "07:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/prompts/oppdateringer.prompt.md
+++ b/.github/prompts/oppdateringer.prompt.md
@@ -1,0 +1,242 @@
+---
+name: ukentlige-oppdateringer
+description: Kjør ukentlige Dependabot-oppdateringer for dette npm/TypeScript-repoet og klargjør for merge til main
+---
+
+Du er en agent som utfører ukentlige avhengighetsoppdateringer for dette repoet. Dependabot har allerede åpnet PRer — din jobb er å samle dem på én branch, løse eventuelle problemer underveis, og klargjøre for menneskelig gjennomgang og merge.
+
+
+## Kontekst om repoet
+
+- **Pakkehåndterer**: `npm`
+- **Tester**: Vitest (`npm run test`)
+- **Build**: Vite / Astro (`npm run build`)
+- **CI/CD**: Deploy til dev skjer via `workflow_dispatch` — ikke nødvendig å deploye som en del av dette oppsettet
+
+
+## Steg 1 — Finn ukenummer og opprett branch
+
+```bash
+WEEK=$(date +%V)
+YEAR=$(date +%Y)
+BRANCH="oppdateringer/uke-${WEEK}-${YEAR}"
+git checkout main
+git pull origin main
+git checkout -b "$BRANCH"
+echo "Branch opprettet: $BRANCH"
+```
+
+
+## Steg 2 — Hent og verifiser åpne Dependabot-PRer
+
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,headRefName,labels,author
+```
+
+### ⚠️ Sikkerhetssjekk før merge
+
+**Verifiser for hver PR at:**
+1. `author.login` er nøyaktig `app/dependabot` — ikke bare at tittelen ser riktig ut
+2. Branch-navnet følger mønsteret `dependabot/<ecosystem>/<pakke>`
+3. Endringer er begrenset til `package.json`, `package-lock.json` eller workflow-filer
+
+```bash
+gh pr view <nr> --json author,headRefName,files \
+  | jq '{author: .author.login, branch: .headRefName, files: [.files[].path]}'
+```
+
+**Ikke merge PRer som:**
+- Har en annen avsender enn `app/dependabot`
+- Inneholder endringer i andre filer enn `package.json`, `package-lock.json` eller GitHub Actions-filer
+
+### ⚠️ Migreringsguide ved major-versjonshopp — ALLTID før merge
+
+Dersom en PR bumper et rammeverk til en **ny major-versjon**, **hent og les migreringsguiden** før du gjør tilpasninger.
+
+| Rammeverk | Migreringsguide-URL |
+|-----------|---------------------|
+| React | `https://react.dev/blog` (søk etter «React <NY_MAJOR>») |
+| Vite | `https://vitejs.dev/guide/migration` eller `MIGRATION.md` i Vite-repoet |
+| Astro | `https://docs.astro.build/en/guides/upgrade-to/v<NY_MAJOR>/` |
+| Vitest | `https://vitest.dev/guide/migration` |
+| TypeScript | `https://www.typescriptlang.org/docs/handbook/release-notes/overview.html` |
+
+```bash
+# Hent migreringsguide — eksempel Vite 7:
+curl -sL "https://raw.githubusercontent.com/vitejs/vite/main/docs/guide/migration.md" | head -150
+
+# Eksempel Astro 5:
+curl -sL "https://raw.githubusercontent.com/withastro/docs/main/src/content/docs/en/guides/upgrade-to/v5.mdx" | head -150
+```
+
+**Les spesielt etter:** `breaking`, `removed`, `renamed`, `requires`, `peer`, `migration`
+
+### ⚠️ Kjente koblinger — sjekk disse ved major-bump
+
+| Pakke som bumpes (major) | Sjekk mot | Hvorfor |
+|---|---|---|
+| `react` | `react-dom`, `@types/react`, andre react-biblioteker | Må ha identisk major-versjon |
+| `vite` | `@vitejs/*`-plugins, `vitest` | Plugin-API endres mellom major-versjoner |
+| `astro` | `@astrojs/*`-integrasjoner | Integrasjoner oppdateres ikke alltid synkront med Astro-major |
+| `vitest` | Test-syntaks og mock-API i eksisterende tester | Major kan endre assertion-API |
+| `typescript` | TypeScript-features brukt i kodebasen | Ny major kan innføre stricter type-checking |
+
+### Prioriter sikkerhets-PRer
+
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,labels \
+  | jq '.[] | select(.labels[].name | test("security"))'
+```
+
+Sikkerhets-PRer (label `security`) merges **før** ordinære oppdateringer.
+
+### Sorteringsrekkefølge
+
+| Prioritet | Kategori |
+|-----------|----------|
+| 1 | GitHub Actions |
+| 2 | TypeScript-typer (`@types/*`) |
+| 3 | Testverktøy (`vitest`, `@vitest/*`) |
+| 4 | Build-verktøy (`vite`, `astro`, `@vitejs/*`, `@astrojs/*`) |
+| 5 | Standalone verktøy (`typescript`, `@testing-library/*`) |
+| 6 | React og rammeverk (`react`, `react-dom`) |
+| 7 | Øvrige produksjonsavhengigheter |
+
+
+## Steg 3 — Merge PRer
+
+For hver PR i sorteringsrekkefølgen:
+
+```bash
+git fetch origin <dependabot-branch>
+git merge origin/<dependabot-branch> --no-edit
+```
+
+Kjør verifisering etter hver PR (eller etter en gruppert Dependabot-PR):
+
+```bash
+npm install
+npm run test
+```
+
+### Dersom `package-lock.json` har merge-konflikter
+
+```bash
+# Regenerer lockfile
+npm install --package-lock-only
+git add package-lock.json
+git commit --amend --no-edit
+```
+
+### Dersom `package.json` har merge-konflikter
+
+```bash
+# Behold begge versjonene — høyeste vinner
+npm install
+npm run test
+git add package.json package-lock.json
+git commit --amend --no-edit
+```
+
+### Dersom tester feiler
+
+1. Les testoutputen nøye
+2. Sjekk migreringsguiden for breaking changes
+3. Gjør nødvendige tilpasninger: `git add -A && git commit -m "fix: tilpass tester etter <pakkenavn>-oppdatering"`
+4. Hvis feilen krever større refaktorering: reverter pakken og logg i oppsummeringen
+
+### Dersom build feiler
+
+```bash
+npm run build
+```
+
+1. Les buildfeilene (typefeil, API-endringer)
+2. Gjør tilpasninger og commit fiksen
+3. Hvis feilen ikke kan løses raskt: reverter pakken og logg
+
+### Revertering
+
+```bash
+git revert HEAD --no-edit
+```
+
+
+## Steg 4 — Push branchen
+
+```bash
+git push origin "$BRANCH"
+```
+
+Vent til CI-bygget er ferdig og grønt:
+
+```bash
+gh run watch $(gh run list --branch "$BRANCH" \
+  --json databaseId --jq '.[0].databaseId') --exit-status
+```
+
+Hvis CI feiler: analyser feilen, reverter aktuelle merger, og logg i oppsummeringen.
+**Ikke lag PR mot main med rødt bygg.**
+
+
+## Steg 5 — Lag en oppsummerings-PR
+
+```bash
+gh pr create \
+  --title "Ukentlige oppdateringer uke ${WEEK}" \
+  --body "$(cat <<'EOF'
+## Ukentlige avhengighetsoppdateringer
+
+Denne PRen samler alle Dependabot-oppdateringer for uken.
+
+### Inkluderte oppdateringer
+<!-- Liste over merget PRer med pakkenavn og versjoner -->
+
+### Skippet oppdateringer
+<!-- PRer som ikke ble inkludert, med begrunnelse -->
+
+### Kodeendringer utover versjons-bump
+<!-- Eventuelle migrasjonstilpasninger -->
+
+### Verifisering
+- [ ] Tester passerer (`npm run test`)
+- [ ] CI-bygg er grønt
+- [ ] Breaking changes er håndtert
+
+Merge til `main` etter godkjenning.
+EOF
+)" \
+  --base main \
+  --head "$BRANCH"
+```
+
+
+## Steg 6 — Instruksjon til mennesket
+
+```
+✅ Branch klar: oppdateringer/uke-<uke-nr>-<år>
+
+Neste steg:
+1. Sjekk at CI-bygget på branchen er grønt (Actions-tab)
+2. Gjennomgå PR-en og eventuelle kodeendringer
+3. Godkjenn og merge PR-en mot main
+
+Merget i denne runden:
+<liste over pakker som ble oppdatert>
+
+Skippet (krever manuell gjennomgang):
+<liste over pakker som ikke ble inkludert, med begrunnelse>
+```
+
+
+## Feilscenarioer og håndtering
+
+| Scenario | Handling |
+|----------|----------|
+| Merge-konflikt i `package-lock.json` | Kjør `npm install --package-lock-only`, commit ny lockfile |
+| Merge-konflikt i `package.json` | Behold høyeste versjon, kjør `npm install` |
+| Testfeil pga. breaking change | Tilpass tester, commit — eller reverter og logg |
+| Buildfeil pga. typefeil | Fiks typefeilen, commit — eller reverter og logg |
+| React major uten matching `react-dom` | Sørg for at `react` og `react-dom` har identisk versjon |
+| Astro major — integrasjon inkompatibel | Sjekk `@astrojs/*`-integrasjons-changelog, reverter og logg hvis ikke oppdatert |
+| Dependabot-branch er utdatert | `gh pr comment <nr> --body "@dependabot rebase"` og vent |

--- a/.github/workflows/ukentlige-oppdateringer.yml
+++ b/.github/workflows/ukentlige-oppdateringer.yml
@@ -16,14 +16,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read  # Nødvendig for actions/checkout
-      issues: write   # Nødvendig for gh issue create
+      contents: write        # Nødvendig for å slette gamle branches
+      issues: write          # Nødvendig for gh issue create
+      pull-requests: write   # Nødvendig for å lukke gamle PRer
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Lukk gammel oppdaterings-PR om den finnes
+        run: |
+          OLD_PRS=$(gh pr list \
+            --state open \
+            --json number,title \
+            --jq '.[] | select(.title | test("Ukentlige oppdateringer uke")) | .number')
+
+          for PR_NUM in $OLD_PRS; do
+            echo "Lukker gammel PR #${PR_NUM}"
+            gh pr close "$PR_NUM" \
+              --comment "Lukkes automatisk — ny ukentlig oppdatering starter nå." \
+              --delete-branch || true
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sørg for at 'dependencies'-label finnes
         run: |

--- a/.github/workflows/ukentlige-oppdateringer.yml
+++ b/.github/workflows/ukentlige-oppdateringer.yml
@@ -1,0 +1,47 @@
+name: Ukentlige oppdateringer
+
+on:
+  schedule:
+    - cron: '0 7 * * 1' # Hver mandag kl. 07:00 UTC
+  workflow_dispatch:     # Kan også kjøres manuelt fra Actions-fanen
+
+# Hindrer parallelle kjøringer — unngår duplikat-issues
+concurrency:
+  group: ukentlige-oppdateringer
+  cancel-in-progress: false
+
+jobs:
+  opprett-issue:
+    name: Opprett oppdaterings-issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read  # Nødvendig for actions/checkout
+      issues: write   # Nødvendig for gh issue create
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Sørg for at 'dependencies'-label finnes
+        run: |
+          gh label create "dependencies" \
+            --color "0075ca" \
+            --description "Dependency updates" 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Opprett issue og tildel Copilot
+        run: |
+          WEEK=$(date +%V)
+          YEAR=$(date +%Y)
+
+          gh issue create \
+            --title "Ukentlige oppdateringer uke ${WEEK} (${YEAR})" \
+            --body-file .github/prompts/oppdateringer.prompt.md \
+            --assignee "@copilot" \
+            --label "dependencies"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ukentlige-oppdateringer.yml
+++ b/.github/workflows/ukentlige-oppdateringer.yml
@@ -2,7 +2,7 @@ name: Ukentlige oppdateringer
 
 on:
   schedule:
-    - cron: '0 7 * * 1' # Hver mandag kl. 07:00 UTC
+    - cron: '0 10 * * 1' # Hver mandag kl. 10:00 UTC (etter at Dependabot har kjørt kl. 07:00)
   workflow_dispatch:     # Kan også kjøres manuelt fra Actions-fanen
 
 # Hindrer parallelle kjøringer — unngår duplikat-issues


### PR DESCRIPTION
## Ukentlig oppdateringsoppsett med GitHub Copilot

Setter opp samme opplegg som team paw har i `paw-brukerstotte`: en GitHub Actions-workflow oppretter automatisk et issue hver mandag kl. 07:00 (norsk tid), tildelt `@copilot`, med en detaljert instruksjonsprompt for å samle og merge Dependabot-PRer.

### Filer lagt til

- `.github/workflows/ukentlige-oppdateringer.yml` — kjøres hver mandag, oppretter issue med prompt som body
- `.github/prompts/oppdateringer.prompt.md` — detaljert instruksjon til Copilot om hvordan samle og merge Dependabot-PRer, inkl. sikkerhetssjekk, sorteringsrekkefølge og migreringsguider ved major-versjonshopp
- `.github/dependabot.yml` — (kun nye repos) konfigurerer Dependabot med ukentlig schedule

### Slik fungerer det

1. Workflow kjøres automatisk hver mandag, eller manuelt fra Actions-fanen
2. Et GitHub Issue opprettes med tittelen "Ukentlige oppdateringer uke XX (YYYY)"
3. Issuen tildeles `@copilot` som leser prompten og utfører oppdateringene:
   - Oppretter en `oppdateringer/uke-XX-YYYY`-branch
   - Merger alle åpne Dependabot-PRer med testing mellom hvert steg
   - Sjekker migreringsguider ved major-versjonshopp
   - Oppretter en PR mot `main` for menneskelig gjennomgang og merge